### PR TITLE
feature(Cache): add cache manager

### DIFF
--- a/src/core/Cache/Cache.ts
+++ b/src/core/Cache/Cache.ts
@@ -1,0 +1,15 @@
+import { game } from "../Game";
+
+export class Cache {
+    private cache: Map<string, unknown> = new Map();
+    private lastTick = -1;
+
+    public rememberForTick<T>(key: string, callback: () => T): T {
+        if (this.lastTick !== game.tick) {
+            this.cache.set(key, callback());
+        }
+        this.lastTick = game.tick;
+
+        return this.cache.get(key) as T;
+    }
+}

--- a/src/core/Cache/CacheManager.ts
+++ b/src/core/Cache/CacheManager.ts
@@ -1,0 +1,9 @@
+import { IManager } from "../Manager";
+import { Cache } from "./Cache";
+
+export class CacheManager implements IManager {
+    public register(): void {}
+}
+
+export const cacheManager = new CacheManager();
+export const cache = new Cache();

--- a/src/core/Cache/index.ts
+++ b/src/core/Cache/index.ts
@@ -1,0 +1,2 @@
+export * from "./CacheManager";
+export * from "./Cache";

--- a/src/core/Game/Game.ts
+++ b/src/core/Game/Game.ts
@@ -1,0 +1,17 @@
+export class Game {
+    private _tick = 0;
+
+    public get tick(): number {
+        return this._tick;
+    }
+
+    public restart(): void {
+        parse("restart");
+    }
+
+    private connector = {
+        increaseTick: () => {
+            this._tick++;
+        },
+    };
+}

--- a/src/core/Game/GameManager.ts
+++ b/src/core/Game/GameManager.ts
@@ -1,0 +1,18 @@
+import { IManager } from "../Manager";
+import { eventManager } from "../Event/EventManager";
+import { AlwaysEvent } from "../Event/events/time";
+import { Game } from "./Game";
+
+const game = new Game();
+const gameConnector = game["connector"];
+
+class GameManager implements IManager {
+    public register(): void {
+        eventManager.on(AlwaysEvent, () => {
+            gameConnector.increaseTick();
+        });
+    }
+}
+
+export const gameManager = new GameManager();
+export { game };

--- a/src/core/Game/index.ts
+++ b/src/core/Game/index.ts
@@ -1,0 +1,2 @@
+export * from "./GameManager";
+export * from "./Game";

--- a/src/core/Player/Player.ts
+++ b/src/core/Player/Player.ts
@@ -1,3 +1,5 @@
+import { cache } from "../Cache";
+
 export class Player {
     private _name: string;
     private _x: number;
@@ -28,6 +30,12 @@ export class Player {
 
     public set speed(speed: number) {
         parse(`speedmod ${this.id} ${speed}`);
+    }
+
+    public get rot(): number {
+        return cache.rememberForTick(this.getCacheKey("rot"), () => {
+            return (player(this.id, "rot") - 90 + 360) % 360;
+        });
     }
 
     public get x(): number {
@@ -74,5 +82,9 @@ export class Player {
 
     public message(message: string): void {
         msg2(this.id, message);
+    }
+
+    private getCacheKey(key: string): string {
+        return `core:player_${this.id}_${key}`;
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { info } from "./utils";
 import { eventManager } from "./core/Event/EventManager";
 import { timeManager } from "./core/Time/TimeManager";
 import { playerManager } from "./core/Player/PlayerManager";
+import { gameManager } from "./core/Game";
+import { cacheManager } from "./core/Cache";
 
 for (const module of modules) {
     module.module.register();
@@ -10,6 +12,8 @@ for (const module of modules) {
 }
 
 eventManager.register();
+cacheManager.register();
+gameManager.register();
 timeManager.register();
 playerManager.register();
 

--- a/src/plugins/demo/main.ts
+++ b/src/plugins/demo/main.ts
@@ -2,6 +2,8 @@ import { eventManager } from "../../core/Event/EventManager";
 import { ConnectEvent, SayEvent } from "../../core/Event/events/player";
 import { Player } from "../../core/Player/Player";
 import { debug } from "../../utils";
+import { Ms100Event } from "../../core/Event/events/time";
+import { playerManager } from "../../core/Player/PlayerManager";
 
 export const registerDemoPlugin = (): void => {
     eventManager.on(ConnectEvent, (player: Player): any => {
@@ -11,5 +13,12 @@ export const registerDemoPlugin = (): void => {
 
     eventManager.on(SayEvent, (player: Player, message: string): any => {
         debug(`____ ${player.name} #${player.usgn} says: ${message}`, true);
+    });
+
+    eventManager.on(Ms100Event, (): any => {
+        for (const playerId of player(0, "table")) {
+            const player = playerManager.getById(playerId)!;
+            debug(`${player.name} rot: ${player.rot}`, true);
+        }
     });
 };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,14 +1,16 @@
 import { color } from "./color";
 
-export function info(message: string, chat: boolean = false) {
+type MessageType = string | number;
+
+export function info(message: MessageType, chat: boolean = false) {
     log(color(116, 110, 255), message, chat);
 }
 
-export function debug(message: string, chat: boolean = false) {
+export function debug(message: MessageType, chat: boolean = false) {
     log(color(180, 180, 100), message, chat);
 }
 
-function log(color: string, message: string, chat: boolean = false) {
+function log(color: string, message: MessageType, chat: boolean = false) {
     const func = chat ? msg : print;
     func(`${color}[Sea]: ${message}`);
 }


### PR DESCRIPTION
This PR introduces a **Cache Manager** that can cache values for a single server tick - for now.

Additionally, it implements player rotation using this cache. It also corrects the player's rotation to align with a standard coordinate system, as opposed to the previous system (DC) which wasn't mathematically accurate.

```ts
class {

    public get rot(): number {
        return cache.rememberForTick(this.getCacheKey("rot"), () => {
            return (player(this.id, "rot") - 90 + 360) % 360;
        });
    }
    
    private getCacheKey(key: string): string {
        return `core:player_${this.id}_${key}`;
    }

}
```

![image](https://github.com/user-attachments/assets/56929cf8-6545-4816-a92a-7fe6d8159187)